### PR TITLE
회원 가입 API 연동

### DIFF
--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -54,7 +54,12 @@ class AppRoutes {
 
       case signUpForm:
         return MaterialPageRoute(
-          builder: (context) => const SignupFormScreen(),
+          builder: (context) {
+            final phoneNumber = settings.arguments is String
+                ? settings.arguments as String
+                : '';
+            return SignupFormScreen(phoneNumber: phoneNumber);
+          },
           settings: settings,
         );
 

--- a/lib/signup/models/enums.dart
+++ b/lib/signup/models/enums.dart
@@ -1,0 +1,52 @@
+import 'package:json_annotation/json_annotation.dart';
+
+enum UserRole {
+  @JsonValue('ROLE_USER')
+  roleUser,
+  @JsonValue('ROLE_ADMIN')
+  roleAdmin,
+}
+
+enum UserSex {
+  @JsonValue('MAN')
+  man,
+  @JsonValue('WOMAN')
+  woman,
+}
+
+enum Level {
+  @JsonValue('V0')
+  v0,
+  @JsonValue('V1')
+  v1,
+  @JsonValue('V2')
+  v2,
+  @JsonValue('V3')
+  v3,
+  @JsonValue('V4')
+  v4,
+  @JsonValue('V5')
+  v5,
+  @JsonValue('V6')
+  v6,
+  @JsonValue('V7')
+  v7,
+  @JsonValue('V8')
+  v8,
+  @JsonValue('V9')
+  v9,
+  @JsonValue('V10')
+  v10,
+  @JsonValue('V11')
+  v11,
+  @JsonValue('V12')
+  v12,
+  @JsonValue('V13')
+  v13,
+  @JsonValue('V14')
+  v14,
+  @JsonValue('V15')
+  v15,
+  @JsonValue('V16')
+  v16,
+}

--- a/lib/signup/models/request/phone_link_request.dart
+++ b/lib/signup/models/request/phone_link_request.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'phone_link_request.g.dart';
+
+@JsonSerializable()
+class PhoneLinkRequest {
+  final String phoneNumber;
+  final String email;
+  final String password;
+
+  PhoneLinkRequest({
+    required this.phoneNumber,
+    required this.email,
+    required this.password,
+  });
+
+  factory PhoneLinkRequest.fromJson(Map<String, dynamic> json) =>
+      _$PhoneLinkRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$PhoneLinkRequestToJson(this);
+}

--- a/lib/signup/models/request/phone_link_request.g.dart
+++ b/lib/signup/models/request/phone_link_request.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_link_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PhoneLinkRequest _$PhoneLinkRequestFromJson(Map<String, dynamic> json) =>
+    PhoneLinkRequest(
+      phoneNumber: json['phoneNumber'] as String,
+      email: json['email'] as String,
+      password: json['password'] as String,
+    );
+
+Map<String, dynamic> _$PhoneLinkRequestToJson(PhoneLinkRequest instance) =>
+    <String, dynamic>{
+      'phoneNumber': instance.phoneNumber,
+      'email': instance.email,
+      'password': instance.password,
+    };

--- a/lib/signup/models/request/phone_lookup_request.dart
+++ b/lib/signup/models/request/phone_lookup_request.dart
@@ -1,0 +1,14 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'phone_lookup_request.g.dart';
+
+@JsonSerializable()
+class PhoneLookupRequest {
+  final String phoneNumber;
+
+  PhoneLookupRequest({required this.phoneNumber});
+
+  factory PhoneLookupRequest.fromJson(Map<String, dynamic> json) =>
+      _$PhoneLookupRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$PhoneLookupRequestToJson(this);
+}

--- a/lib/signup/models/request/phone_lookup_request.g.dart
+++ b/lib/signup/models/request/phone_lookup_request.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_lookup_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PhoneLookupRequest _$PhoneLookupRequestFromJson(Map<String, dynamic> json) =>
+    PhoneLookupRequest(phoneNumber: json['phoneNumber'] as String);
+
+Map<String, dynamic> _$PhoneLookupRequestToJson(PhoneLookupRequest instance) =>
+    <String, dynamic>{'phoneNumber': instance.phoneNumber};

--- a/lib/signup/models/request/signup_request.dart
+++ b/lib/signup/models/request/signup_request.dart
@@ -1,0 +1,31 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:boulderside_flutter/signup/models/enums.dart';
+
+part 'signup_request.g.dart';
+
+@JsonSerializable()
+class SignupRequest {
+  final String nickname;
+  final String phone;
+  final UserRole userRole;
+  final UserSex userSex;
+  final Level userLevel;
+  final String? name;
+  final String email;
+  final String password;
+
+  SignupRequest({
+    required this.nickname,
+    required this.phone,
+    required this.userRole,
+    required this.userSex,
+    required this.userLevel,
+    this.name,
+    required this.email,
+    required this.password,
+  });
+
+  factory SignupRequest.fromJson(Map<String, dynamic> json) =>
+      _$SignupRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$SignupRequestToJson(this);
+}

--- a/lib/signup/models/request/signup_request.g.dart
+++ b/lib/signup/models/request/signup_request.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'signup_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SignupRequest _$SignupRequestFromJson(Map<String, dynamic> json) =>
+    SignupRequest(
+      nickname: json['nickname'] as String,
+      phone: json['phone'] as String,
+      userRole: $enumDecode(_$UserRoleEnumMap, json['userRole']),
+      userSex: $enumDecode(_$UserSexEnumMap, json['userSex']),
+      userLevel: $enumDecode(_$LevelEnumMap, json['userLevel']),
+      name: json['name'] as String?,
+      email: json['email'] as String,
+      password: json['password'] as String,
+    );
+
+Map<String, dynamic> _$SignupRequestToJson(SignupRequest instance) =>
+    <String, dynamic>{
+      'nickname': instance.nickname,
+      'phone': instance.phone,
+      'userRole': _$UserRoleEnumMap[instance.userRole]!,
+      'userSex': _$UserSexEnumMap[instance.userSex]!,
+      'userLevel': _$LevelEnumMap[instance.userLevel]!,
+      'name': instance.name,
+      'email': instance.email,
+      'password': instance.password,
+    };
+
+const _$UserRoleEnumMap = {
+  UserRole.roleUser: 'ROLE_USER',
+  UserRole.roleAdmin: 'ROLE_ADMIN',
+};
+
+const _$UserSexEnumMap = {UserSex.man: 'MAN', UserSex.woman: 'WOMAN'};
+
+const _$LevelEnumMap = {
+  Level.v0: 'V0',
+  Level.v1: 'V1',
+  Level.v2: 'V2',
+  Level.v3: 'V3',
+  Level.v4: 'V4',
+  Level.v5: 'V5',
+  Level.v6: 'V6',
+  Level.v7: 'V7',
+  Level.v8: 'V8',
+  Level.v9: 'V9',
+  Level.v10: 'V10',
+  Level.v11: 'V11',
+  Level.v12: 'V12',
+  Level.v13: 'V13',
+  Level.v14: 'V14',
+  Level.v15: 'V15',
+  Level.v16: 'V16',
+};

--- a/lib/signup/models/response/phone_lookup_response.dart
+++ b/lib/signup/models/response/phone_lookup_response.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:boulderside_flutter/signup/models/enums.dart';
+
+part 'phone_lookup_response.g.dart';
+
+@JsonSerializable()
+class PhoneLookupResponse {
+  final bool exists;
+  final String? nickname;
+  final String? phone;
+  final UserRole? userRole;
+  final UserSex? userSex;
+  final Level? userLevel;
+  final String? name;
+
+  PhoneLookupResponse({
+    required this.exists,
+    this.nickname,
+    this.phone,
+    this.userRole,
+    this.userSex,
+    this.userLevel,
+    this.name,
+  });
+
+  factory PhoneLookupResponse.fromJson(Map<String, dynamic> json) =>
+      _$PhoneLookupResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$PhoneLookupResponseToJson(this);
+}

--- a/lib/signup/models/response/phone_lookup_response.g.dart
+++ b/lib/signup/models/response/phone_lookup_response.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_lookup_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PhoneLookupResponse _$PhoneLookupResponseFromJson(Map<String, dynamic> json) =>
+    PhoneLookupResponse(
+      exists: json['exists'] as bool,
+      nickname: json['nickname'] as String?,
+      phone: json['phone'] as String?,
+      userRole: $enumDecodeNullable(_$UserRoleEnumMap, json['userRole']),
+      userSex: $enumDecodeNullable(_$UserSexEnumMap, json['userSex']),
+      userLevel: $enumDecodeNullable(_$LevelEnumMap, json['userLevel']),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$PhoneLookupResponseToJson(
+  PhoneLookupResponse instance,
+) => <String, dynamic>{
+  'exists': instance.exists,
+  'nickname': instance.nickname,
+  'phone': instance.phone,
+  'userRole': _$UserRoleEnumMap[instance.userRole],
+  'userSex': _$UserSexEnumMap[instance.userSex],
+  'userLevel': _$LevelEnumMap[instance.userLevel],
+  'name': instance.name,
+};
+
+const _$UserRoleEnumMap = {
+  UserRole.roleUser: 'ROLE_USER',
+  UserRole.roleAdmin: 'ROLE_ADMIN',
+};
+
+const _$UserSexEnumMap = {UserSex.man: 'MAN', UserSex.woman: 'WOMAN'};
+
+const _$LevelEnumMap = {
+  Level.v0: 'V0',
+  Level.v1: 'V1',
+  Level.v2: 'V2',
+  Level.v3: 'V3',
+  Level.v4: 'V4',
+  Level.v5: 'V5',
+  Level.v6: 'V6',
+  Level.v7: 'V7',
+  Level.v8: 'V8',
+  Level.v9: 'V9',
+  Level.v10: 'V10',
+  Level.v11: 'V11',
+  Level.v12: 'V12',
+  Level.v13: 'V13',
+  Level.v14: 'V14',
+  Level.v15: 'V15',
+  Level.v16: 'V16',
+};

--- a/lib/signup/screens/signup_form.dart
+++ b/lib/signup/screens/signup_form.dart
@@ -1,53 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../widgets/terms_row.dart';
+import '../widgets/success_dialog.dart';
+import '../viewmodels/signup_form_view_model.dart';
+import '../services/signup_form_service.dart';
 
 class SignupFormScreen extends StatefulWidget {
-  const SignupFormScreen({super.key});
+  final String phoneNumber;
+
+  const SignupFormScreen({super.key, required this.phoneNumber});
 
   @override
   State<SignupFormScreen> createState() => _SignupFormScreenState();
 }
 
 class _SignupFormScreenState extends State<SignupFormScreen> {
-  final TextEditingController _emailController = TextEditingController();
-  final TextEditingController _passwordController = TextEditingController();
-  final TextEditingController _passwordConfirmController =
-      TextEditingController();
-  final TextEditingController _nameController = TextEditingController();
-
-  String? _selectedGender;
-
-  // 이메일 중복확인 상태 변수
-  bool _emailDuplicateChecked = false;
-
-  bool _agreeTerms1 = false;
-  bool _agreeTerms2 = false;
-  bool _agreeTerms3 = false;
-
-  bool get _allFieldsFilled =>
-      _emailController.text.trim().isNotEmpty &&
-      _passwordController.text.isNotEmpty &&
-      _passwordConfirmController.text.isNotEmpty &&
-      _nameController.text.trim().isNotEmpty &&
-      _passwordController.text == _passwordConfirmController.text &&
-      //_passwordController.text.length >= 6 && 6자리 이상은 추후에 고려하기
-      _selectedGender != null &&
-      _emailDuplicateChecked;
-
-  bool get _allTermsAgreed => _agreeTerms1 && _agreeTerms2 && _agreeTerms3;
-
-  bool get _canSubmit => _allFieldsFilled && _allTermsAgreed;
-
   @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    _passwordConfirmController.dispose();
-    _nameController.dispose();
-    super.dispose();
+  void initState() {
+    super.initState();
   }
-
-  void _onChanged(_) => setState(() {});
 
   void _showComingSoon() {
     ScaffoldMessenger.of(
@@ -55,612 +26,690 @@ class _SignupFormScreenState extends State<SignupFormScreen> {
     ).showSnackBar(const SnackBar(content: Text('준비 중입니다.')));
   }
 
-  void _checkEmailDuplicate() {
-    final email = _emailController.text.trim();
-
-    // API가 없으므로 일단 사용가능하다고 처리
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          backgroundColor: const Color(0xFF181A20),
-          title: const Text(
-            '중복확인 완료',
-            style: TextStyle(
-              fontFamily: 'Pretendard',
-              color: Colors.white,
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          content: const Text(
-            '사용가능한 아이디입니다.',
-            style: TextStyle(
-              fontFamily: 'Pretendard',
-              color: Colors.white,
-              fontSize: 16,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text(
-                '확인',
-                style: TextStyle(
-                  fontFamily: 'Pretendard',
-                  color: Color(0xFFFF3278),
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
-
-    setState(() {
-      _emailDuplicateChecked = true;
-    });
-  }
-
-  void _handleSubmit() {
-    // TODO: 실제 회원가입 API 연동 예정
-    Navigator.pushNamedAndRemoveUntil(context, '/', (route) => false);
+  void _showSuccessDialog(BuildContext context, bool isExistingUser) {
+    SuccessDialog.show(context, isExistingUser);
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF181A20),
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.white),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: const Text(
-          '회원가입',
-          style: TextStyle(
-            fontFamily: 'Pretendard',
-            color: Colors.white,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        centerTitle: true,
-      ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            // 스크롤 가능한 내용
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const SizedBox(height: 12),
+    return ChangeNotifierProvider(
+      create: (_) {
+        final viewModel = SignupFormViewModel(SignupFormService());
+        viewModel.lookupUserByPhone(widget.phoneNumber);
+        return viewModel;
+      },
+      child: Consumer<SignupFormViewModel>(
+        builder: (context, viewModel, child) {
+          // 성공 시 다이얼로그 표시 및 로그인 화면으로 이동
+          if (viewModel.isSuccess) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _showSuccessDialog(context, viewModel.isExistingUser);
+            });
+          }
 
-                    // 입력 필드를 먼저 배치하도록 순서 조정 (프로필 이미지는 아래로 이동)
-                    const SizedBox(height: 12),
+          // 로딩 중일 때 표시
+          if (viewModel.isLoadingLookup) {
+            return Scaffold(
+              backgroundColor: const Color(0xFF181A20),
+              appBar: AppBar(
+                backgroundColor: Colors.transparent,
+                elevation: 0,
+                leading: IconButton(
+                  icon: const Icon(Icons.arrow_back, color: Colors.white),
+                  onPressed: () => Navigator.pop(context),
+                ),
+                title: const Text(
+                  '회원가입',
+                  style: TextStyle(
+                    fontFamily: 'Pretendard',
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                centerTitle: true,
+              ),
+              body: const Center(
+                child: CircularProgressIndicator(
+                  valueColor: AlwaysStoppedAnimation<Color>(Color(0xFFFF3278)),
+                ),
+              ),
+            );
+          }
 
-                    // 이메일
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '아이디',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextField(
-                                controller: _emailController,
-                                onChanged: _onChanged,
-                                enabled: !_emailDuplicateChecked,
-                                keyboardType: TextInputType.text,
-                                style: TextStyle(
-                                  fontFamily: 'Pretendard',
-                                  color: _emailDuplicateChecked
-                                      ? Colors.grey[400]
-                                      : Colors.white,
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w400,
-                                ),
-                                decoration: InputDecoration(
-                                  hintText: '아이디를 입력하세요',
-                                  hintStyle: TextStyle(
-                                    fontFamily: 'Pretendard',
-                                    color: _emailDuplicateChecked
-                                        ? Colors.grey[500]
-                                        : Colors.grey[600],
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w400,
-                                  ),
-                                  filled: true,
-                                  fillColor: _emailDuplicateChecked
-                                      ? Colors.grey[800]
-                                      : const Color.fromRGBO(
-                                          130,
-                                          145,
-                                          179,
-                                          0.1333,
+          return Scaffold(
+            backgroundColor: const Color(0xFF181A20),
+            appBar: AppBar(
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.white),
+                onPressed: () => Navigator.pop(context),
+              ),
+              title: Text(
+                viewModel.isExistingUser ? '계정 연동' : '회원가입',
+                style: const TextStyle(
+                  fontFamily: 'Pretendard',
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              centerTitle: true,
+            ),
+            body: SafeArea(
+              child: Column(
+                children: [
+                  // 스크롤 가능한 내용
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const SizedBox(height: 12),
+
+                          // 입력 필드를 먼저 배치하도록 순서 조정 (프로필 이미지는 아래로 이동)
+                          const SizedBox(height: 12),
+
+                          // 이메일
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextField(
+                                      controller: viewModel.emailController,
+                                      onChanged: (_) =>
+                                          viewModel.onFieldChanged(),
+                                      enabled: !viewModel.emailDuplicateChecked,
+                                      keyboardType: TextInputType.text,
+                                      style: TextStyle(
+                                        fontFamily: 'Pretendard',
+                                        color: viewModel.emailDuplicateChecked
+                                            ? Colors.grey[400]
+                                            : Colors.white,
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w400,
+                                      ),
+                                      decoration: InputDecoration(
+                                        hintText: '아이디를 입력하세요',
+                                        hintStyle: TextStyle(
+                                          fontFamily: 'Pretendard',
+                                          color: viewModel.emailDuplicateChecked
+                                              ? Colors.grey[500]
+                                              : Colors.grey[600],
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w400,
                                         ),
-                                  border: const OutlineInputBorder(
-                                    borderSide: BorderSide(
-                                      color: Colors.transparent,
-                                    ),
-                                    borderRadius: BorderRadius.all(
-                                      Radius.circular(8),
-                                    ),
-                                  ),
-                                  enabledBorder: const OutlineInputBorder(
-                                    borderSide: BorderSide(
-                                      color: Colors.transparent,
-                                    ),
-                                    borderRadius: BorderRadius.all(
-                                      Radius.circular(8),
-                                    ),
-                                  ),
-                                  focusedBorder: OutlineInputBorder(
-                                    borderSide: BorderSide(
-                                      color: _emailDuplicateChecked
-                                          ? Colors.grey[700]!
-                                          : Colors.grey[600]!,
-                                    ),
-                                    borderRadius: const BorderRadius.all(
-                                      Radius.circular(8),
-                                    ),
-                                  ),
-                                  disabledBorder: OutlineInputBorder(
-                                    borderSide: BorderSide(
-                                      color: Colors.grey[700]!,
-                                    ),
-                                    borderRadius: const BorderRadius.all(
-                                      Radius.circular(8),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            SizedBox(
-                              height: 56,
-                              child: ElevatedButton(
-                                onPressed:
-                                    _emailController.text.trim().isNotEmpty
-                                    ? _checkEmailDuplicate
-                                    : null,
-                                style: ButtonStyle(
-                                  backgroundColor:
-                                      MaterialStateProperty.resolveWith<Color?>(
-                                        (states) {
-                                          if (states.contains(
-                                            MaterialState.disabled,
-                                          )) {
-                                            return Colors.grey[700];
-                                          }
-                                          return const Color(0xFFFF3278);
-                                        },
-                                      ),
-                                  foregroundColor:
-                                      MaterialStateProperty.all<Color>(
-                                        Colors.white,
-                                      ),
-                                  shape:
-                                      MaterialStateProperty.all<
-                                        RoundedRectangleBorder
-                                      >(
-                                        RoundedRectangleBorder(
-                                          borderRadius: BorderRadius.circular(
-                                            8,
+                                        filled: true,
+                                        fillColor:
+                                            viewModel.emailDuplicateChecked
+                                            ? Colors.grey[800]
+                                            : const Color.fromRGBO(
+                                                130,
+                                                145,
+                                                179,
+                                                0.1333,
+                                              ),
+                                        border: const OutlineInputBorder(
+                                          borderSide: BorderSide(
+                                            color: Colors.transparent,
+                                          ),
+                                          borderRadius: BorderRadius.all(
+                                            Radius.circular(8),
+                                          ),
+                                        ),
+                                        enabledBorder: const OutlineInputBorder(
+                                          borderSide: BorderSide(
+                                            color: Colors.transparent,
+                                          ),
+                                          borderRadius: BorderRadius.all(
+                                            Radius.circular(8),
+                                          ),
+                                        ),
+                                        focusedBorder: OutlineInputBorder(
+                                          borderSide: BorderSide(
+                                            color:
+                                                viewModel.emailDuplicateChecked
+                                                ? Colors.grey[700]!
+                                                : Colors.grey[600]!,
+                                          ),
+                                          borderRadius: const BorderRadius.all(
+                                            Radius.circular(8),
+                                          ),
+                                        ),
+                                        disabledBorder: OutlineInputBorder(
+                                          borderSide: BorderSide(
+                                            color: Colors.grey[700]!,
+                                          ),
+                                          borderRadius: const BorderRadius.all(
+                                            Radius.circular(8),
                                           ),
                                         ),
                                       ),
-                                  elevation: MaterialStateProperty.all<double>(
-                                    0,
+                                    ),
                                   ),
-                                ),
-                                child: const Text(
-                                  '중복확인',
-                                  style: TextStyle(
-                                    fontFamily: 'Pretendard',
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w600,
+                                  const SizedBox(width: 12),
+                                  SizedBox(
+                                    height: 56,
+                                    child: ElevatedButton(
+                                      onPressed: viewModel.isCheckingEmail
+                                          ? null
+                                          : viewModel.emailController.text
+                                                .trim()
+                                                .isNotEmpty
+                                          ? () async => await viewModel
+                                                .checkEmailDuplicate()
+                                          : null,
+                                      style: ButtonStyle(
+                                        backgroundColor:
+                                            MaterialStateProperty.resolveWith<
+                                              Color?
+                                            >((states) {
+                                              if (states.contains(
+                                                MaterialState.disabled,
+                                              )) {
+                                                return Colors.grey[700];
+                                              }
+                                              return const Color(0xFFFF3278);
+                                            }),
+                                        foregroundColor:
+                                            MaterialStateProperty.all<Color>(
+                                              Colors.white,
+                                            ),
+                                        shape:
+                                            MaterialStateProperty.all<
+                                              RoundedRectangleBorder
+                                            >(
+                                              RoundedRectangleBorder(
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
+                                              ),
+                                            ),
+                                        elevation:
+                                            MaterialStateProperty.all<double>(
+                                              0,
+                                            ),
+                                      ),
+                                      child: viewModel.isCheckingEmail
+                                          ? const SizedBox(
+                                              width: 16,
+                                              height: 16,
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                                valueColor:
+                                                    AlwaysStoppedAnimation<
+                                                      Color
+                                                    >(Colors.white),
+                                              ),
+                                            )
+                                          : const Text(
+                                              '중복확인',
+                                              style: TextStyle(
+                                                fontFamily: 'Pretendard',
+                                                fontSize: 14,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                            ),
+                                    ),
                                   ),
+                                ],
+                              ),
+                            ],
+                          ),
+
+                          // 에러 메시지 표시
+                          if (viewModel.errorMessage != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8.0),
+                              child: Text(
+                                viewModel.errorMessage!,
+                                style: const TextStyle(
+                                  fontFamily: 'Pretendard',
+                                  color: Color(0xFFFF5252),
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w500,
                                 ),
                               ),
                             ),
-                          ],
-                        ),
-                      ],
-                    ),
 
-                    const SizedBox(height: 16),
+                          const SizedBox(height: 16),
 
-                    // 비밀번호
-                    TextField(
-                      controller: _passwordController,
-                      onChanged: _onChanged,
-                      obscureText: true,
-                      style: const TextStyle(
-                        fontFamily: 'Pretendard',
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      decoration: InputDecoration(
-                        labelText: '비밀번호',
-                        labelStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[400],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                        ),
-                        hintText: '비밀번호를 입력하세요 (6자 이상)',
-                        hintStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[600],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                        ),
-                        filled: true,
-                        fillColor: const Color.fromRGBO(130, 145, 179, 0.1333),
-                        border: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        enabledBorder: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.grey[600]!),
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(8),
-                          ),
-                        ),
-                      ),
-                    ),
-
-                    const SizedBox(height: 16),
-
-                    // 비밀번호 확인
-                    TextField(
-                      controller: _passwordConfirmController,
-                      onChanged: _onChanged,
-                      obscureText: true,
-                      style: const TextStyle(
-                        fontFamily: 'Pretendard',
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      decoration: InputDecoration(
-                        labelText: '비밀번호를 다시 입력해주세요',
-                        labelStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[400],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                        ),
-                        hintText: '비밀번호를 다시 입력하세요',
-                        hintStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[600],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                        ),
-                        filled: true,
-                        fillColor: const Color.fromRGBO(130, 145, 179, 0.1333),
-                        border: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        enabledBorder: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.grey[600]!),
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(8),
-                          ),
-                        ),
-                      ),
-                    ),
-
-                    // 비밀번호 일치 여부 안내 텍스트
-                    Builder(
-                      builder: (_) {
-                        final hasPassword = _passwordController.text.isNotEmpty;
-                        final hasConfirm =
-                            _passwordConfirmController.text.isNotEmpty;
-                        if (!hasPassword && !hasConfirm) {
-                          return const SizedBox(height: 0);
-                        }
-                        final matches =
-                            _passwordController.text ==
-                            _passwordConfirmController.text;
-                        return Padding(
-                          padding: const EdgeInsets.only(top: 8.0),
-                          child: Text(
-                            matches ? '비밀번호가 일치합니다.' : '비밀번호가 일치하지 않습니다.',
-                            style: TextStyle(
-                              fontFamily: 'Pretendard',
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                              color: matches
-                                  ? const Color(0xFF00C853)
-                                  : const Color(0xFFFF5252),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-
-                    const SizedBox(height: 24),
-
-                    // 프로필 이미지 (원형) - 입력 필드 아래로 이동, 크기 확대
-                    Center(
-                      child: Stack(
-                        children: [
-                          const CircleAvatar(
-                            radius: 56,
-                            backgroundColor: Color(0xFF2A2F3A),
-                            child: Icon(
-                              Icons.person,
-                              size: 56,
-                              color: Colors.white70,
-                            ),
-                          ),
-                          Positioned(
-                            right: 0,
-                            bottom: 0,
-                            child: InkWell(
-                              onTap: _showComingSoon,
-                              child: Container(
-                                decoration: const BoxDecoration(
-                                  color: Color(0xFFFF3278),
-                                  shape: BoxShape.circle,
-                                ),
-                                padding: const EdgeInsets.all(8),
-                                child: const Icon(
-                                  Icons.camera_alt,
-                                  size: 18,
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-
-                    const SizedBox(height: 16),
-
-                    // 이름 또는 닉네임 (프로필 이미지 아래로 이동)
-                    TextField(
-                      controller: _nameController,
-                      onChanged: _onChanged,
-                      style: const TextStyle(
-                        fontFamily: 'Pretendard',
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w400,
-                      ),
-                      decoration: InputDecoration(
-                        labelText: '이름 또는 닉네임을 입력해주세요',
-                        labelStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[400],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                        ),
-                        hintText: '이름 또는 닉네임',
-                        hintStyle: TextStyle(
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[600],
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                        ),
-                        filled: true,
-                        fillColor: const Color.fromRGBO(130, 145, 179, 0.1333),
-                        border: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        enabledBorder: const OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.transparent),
-                          borderRadius: BorderRadius.all(Radius.circular(8)),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.grey[600]!),
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(8),
-                          ),
-                        ),
-                      ),
-                    ),
-
-                    const SizedBox(height: 16),
-
-                    // 성별 선택
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '성별',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: RadioListTile<String>(
-                                title: Text(
-                                  '남성',
-                                  style: TextStyle(
-                                    fontFamily: 'Pretendard',
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w400,
-                                  ),
-                                ),
-                                value: 'male',
-                                groupValue: _selectedGender,
-                                onChanged: (value) {
-                                  setState(() {
-                                    _selectedGender = value;
-                                  });
-                                },
-                                activeColor: const Color(0xFFFF3278),
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                            ),
-                            Expanded(
-                              child: RadioListTile<String>(
-                                title: Text(
-                                  '여성',
-                                  style: TextStyle(
-                                    fontFamily: 'Pretendard',
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w400,
-                                  ),
-                                ),
-                                value: 'female',
-                                groupValue: _selectedGender,
-                                onChanged: (value) {
-                                  setState(() {
-                                    _selectedGender = value;
-                                  });
-                                },
-                                activeColor: const Color(0xFFFF3278),
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-
-                    const SizedBox(height: 12),
-                    Container(height: 1, color: Colors.grey[700]),
-                    const SizedBox(height: 12),
-
-                    // 이용약관 동의 섹션
-                    Container(
-                      padding: const EdgeInsets.all(16),
-                      decoration: BoxDecoration(
-                        color: const Color.fromRGBO(130, 145, 179, 0.1333),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          // 이용약관 제목
-                          Text(
-                            '이용약관',
-                            style: TextStyle(
+                          // 비밀번호
+                          TextField(
+                            controller: viewModel.passwordController,
+                            onChanged: (_) => viewModel.onFieldChanged(),
+                            obscureText: true,
+                            style: const TextStyle(
                               fontFamily: 'Pretendard',
                               color: Colors.white,
                               fontSize: 16,
-                              fontWeight: FontWeight.w600,
+                              fontWeight: FontWeight.w400,
+                            ),
+                            decoration: InputDecoration(
+                              labelText: '비밀번호',
+                              labelStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: Colors.grey[400],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              hintText: '비밀번호를 입력하세요 (6자 이상)',
+                              hintStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: Colors.grey[600],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              filled: true,
+                              fillColor: const Color.fromRGBO(
+                                130,
+                                145,
+                                179,
+                                0.1333,
+                              ),
+                              border: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              enabledBorder: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.grey[600]!,
+                                ),
+                                borderRadius: const BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
                             ),
                           ),
+
                           const SizedBox(height: 16),
 
-                          // 약관 동의 항목들
-                          TermsRow(
-                            label: '[필수] 이용약관 동의',
-                            checked: _agreeTerms1,
-                            onChanged: (v) =>
-                                setState(() => _agreeTerms1 = v ?? false),
-                            onView: _showComingSoon,
+                          // 비밀번호 확인
+                          TextField(
+                            controller: viewModel.passwordConfirmController,
+                            onChanged: (_) => viewModel.onFieldChanged(),
+                            obscureText: true,
+                            style: const TextStyle(
+                              fontFamily: 'Pretendard',
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w400,
+                            ),
+                            decoration: InputDecoration(
+                              labelText: '비밀번호를 다시 입력해주세요',
+                              labelStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: Colors.grey[400],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              hintText: '비밀번호를 다시 입력하세요',
+                              hintStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: Colors.grey[600],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              filled: true,
+                              fillColor: const Color.fromRGBO(
+                                130,
+                                145,
+                                179,
+                                0.1333,
+                              ),
+                              border: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              enabledBorder: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.grey[600]!,
+                                ),
+                                borderRadius: const BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                            ),
                           ),
-                          TermsRow(
-                            label: '[필수] 개인정보 처리방침 동의',
-                            checked: _agreeTerms2,
-                            onChanged: (v) =>
-                                setState(() => _agreeTerms2 = v ?? false),
-                            onView: _showComingSoon,
+
+                          // 비밀번호 일치 여부 안내 텍스트
+                          Builder(
+                            builder: (_) {
+                              final hasPassword =
+                                  viewModel.passwordController.text.isNotEmpty;
+                              final hasConfirm = viewModel
+                                  .passwordConfirmController
+                                  .text
+                                  .isNotEmpty;
+                              if (!hasPassword && !hasConfirm) {
+                                return const SizedBox(height: 0);
+                              }
+                              final matches =
+                                  viewModel.passwordController.text ==
+                                  viewModel.passwordConfirmController.text;
+                              return Padding(
+                                padding: const EdgeInsets.only(top: 8.0),
+                                child: Text(
+                                  matches ? '비밀번호가 일치합니다.' : '비밀번호가 일치하지 않습니다.',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                    color: matches
+                                        ? const Color(0xFF00C853)
+                                        : const Color(0xFFFF5252),
+                                  ),
+                                ),
+                              );
+                            },
                           ),
-                          TermsRow(
-                            label: '[필수] 만 14세 이상입니다',
-                            checked: _agreeTerms3,
-                            onChanged: (v) =>
-                                setState(() => _agreeTerms3 = v ?? false),
-                            onView: _showComingSoon,
+
+                          const SizedBox(height: 24),
+
+                          // 프로필 이미지 (원형) - 입력 필드 아래로 이동, 크기 확대
+                          Center(
+                            child: Stack(
+                              children: [
+                                const CircleAvatar(
+                                  radius: 56,
+                                  backgroundColor: Color(0xFF2A2F3A),
+                                  child: Icon(
+                                    Icons.person,
+                                    size: 56,
+                                    color: Colors.white70,
+                                  ),
+                                ),
+                                Positioned(
+                                  right: 0,
+                                  bottom: 0,
+                                  child: InkWell(
+                                    onTap: _showComingSoon,
+                                    child: Container(
+                                      decoration: const BoxDecoration(
+                                        color: Color(0xFFFF3278),
+                                        shape: BoxShape.circle,
+                                      ),
+                                      padding: const EdgeInsets.all(8),
+                                      child: const Icon(
+                                        Icons.camera_alt,
+                                        size: 18,
+                                        color: Colors.white,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
+
+                          const SizedBox(height: 16),
+
+                          // 이름 또는 닉네임 (프로필 이미지 아래로 이동)
+                          TextField(
+                            controller: viewModel.nameController,
+                            onChanged: (_) => viewModel.onFieldChanged(),
+                            enabled: !viewModel.isExistingUser,
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              color: viewModel.isExistingUser
+                                  ? Colors.grey[400]
+                                  : Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w400,
+                            ),
+                            decoration: InputDecoration(
+                              labelText: viewModel.isExistingUser
+                                  ? null
+                                  : '이름 또는 닉네임을 입력해주세요',
+                              labelStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: Colors.grey[400],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              hintText: '이름 또는 닉네임',
+                              hintStyle: TextStyle(
+                                fontFamily: 'Pretendard',
+                                color: viewModel.isExistingUser
+                                    ? Colors.grey[500]
+                                    : Colors.grey[600],
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              filled: true,
+                              fillColor: viewModel.isExistingUser
+                                  ? Colors.grey[800]
+                                  : const Color.fromRGBO(130, 145, 179, 0.1333),
+                              border: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              enabledBorder: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.transparent,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: viewModel.isExistingUser
+                                      ? Colors.grey[700]!
+                                      : Colors.grey[600]!,
+                                ),
+                                borderRadius: const BorderRadius.all(
+                                  Radius.circular(8),
+                                ),
+                              ),
+                            ),
+                          ),
+
+                          // 성별 선택 (신규 사용자만 표시)
+                          if (!viewModel.isExistingUser) ...[
+                            const SizedBox(height: 16),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '성별',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    color: Colors.grey[400],
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: RadioListTile<String>(
+                                        title: Text(
+                                          '남성',
+                                          style: TextStyle(
+                                            fontFamily: 'Pretendard',
+                                            color: Colors.white,
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w400,
+                                          ),
+                                        ),
+                                        value: 'male',
+                                        groupValue: viewModel.selectedGender,
+                                        onChanged: (value) {
+                                          viewModel.selectGender(value);
+                                        },
+                                        activeColor: const Color(0xFFFF3278),
+                                        contentPadding: EdgeInsets.zero,
+                                      ),
+                                    ),
+                                    Expanded(
+                                      child: RadioListTile<String>(
+                                        title: Text(
+                                          '여성',
+                                          style: TextStyle(
+                                            fontFamily: 'Pretendard',
+                                            color: Colors.white,
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w400,
+                                          ),
+                                        ),
+                                        value: 'female',
+                                        groupValue: viewModel.selectedGender,
+                                        onChanged: (value) {
+                                          viewModel.selectGender(value);
+                                        },
+                                        activeColor: const Color(0xFFFF3278),
+                                        contentPadding: EdgeInsets.zero,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ],
+
+                          const SizedBox(height: 12),
+                          Container(height: 1, color: Colors.grey[700]),
+                          const SizedBox(height: 12),
+
+                          // 이용약관 동의 섹션
+                          Container(
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: const Color.fromRGBO(
+                                130,
+                                145,
+                                179,
+                                0.1333,
+                              ),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                // 이용약관 제목
+                                Text(
+                                  '이용약관',
+                                  style: TextStyle(
+                                    fontFamily: 'Pretendard',
+                                    color: Colors.white,
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: 16),
+
+                                // 약관 동의 항목들
+                                TermsRow(
+                                  label: '[필수] 이용약관 동의',
+                                  checked: viewModel.agreeTerms1,
+                                  onChanged: (v) => viewModel.toggleTerms1(),
+                                  onView: _showComingSoon,
+                                ),
+                                TermsRow(
+                                  label: '[필수] 개인정보 처리방침 동의',
+                                  checked: viewModel.agreeTerms2,
+                                  onChanged: (v) => viewModel.toggleTerms2(),
+                                  onView: _showComingSoon,
+                                ),
+                                TermsRow(
+                                  label: '[필수] 만 14세 이상입니다',
+                                  checked: viewModel.agreeTerms3,
+                                  onChanged: (v) => viewModel.toggleTerms3(),
+                                  onView: _showComingSoon,
+                                ),
+                              ],
+                            ),
+                          ),
+
+                          const SizedBox(height: 24),
                         ],
                       ),
                     ),
+                  ),
 
-                    const SizedBox(height: 24),
-                  ],
-                ),
-              ),
-            ),
-
-            // 하단 고정 회원가입 버튼
-            Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 24.0,
-                vertical: 16.0,
-              ),
-              child: SizedBox(
-                width: double.infinity,
-                height: 50,
-                child: ElevatedButton(
-                  onPressed: _canSubmit ? _handleSubmit : null,
-                  style: ButtonStyle(
-                    backgroundColor: MaterialStateProperty.resolveWith<Color?>((
-                      states,
-                    ) {
-                      if (states.contains(MaterialState.disabled)) {
-                        return Colors.grey[700];
-                      }
-                      return const Color(0xFFFF3278);
-                    }),
-                    foregroundColor: MaterialStateProperty.all<Color>(
-                      Colors.white,
+                  // 하단 고정 회원가입 버튼
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24.0,
+                      vertical: 16.0,
                     ),
-                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                      RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                    child: SizedBox(
+                      width: double.infinity,
+                      height: 50,
+                      child: ElevatedButton(
+                        onPressed: viewModel.canSubmit
+                            ? () => viewModel.handleSubmit(widget.phoneNumber)
+                            : null,
+                        style: ButtonStyle(
+                          backgroundColor:
+                              MaterialStateProperty.resolveWith<Color?>((
+                                states,
+                              ) {
+                                if (states.contains(MaterialState.disabled)) {
+                                  return Colors.grey[700];
+                                }
+                                return const Color(0xFFFF3278);
+                              }),
+                          foregroundColor: MaterialStateProperty.all<Color>(
+                            Colors.white,
+                          ),
+                          shape:
+                              MaterialStateProperty.all<RoundedRectangleBorder>(
+                                RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                              ),
+                          elevation: MaterialStateProperty.all<double>(0),
+                        ),
+                        child: Text(
+                          viewModel.isExistingUser ? '연동하기' : '회원가입',
+                          style: const TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
                       ),
                     ),
-                    elevation: MaterialStateProperty.all<double>(0),
                   ),
-                  child: const Text(
-                    '회원가입',
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
+                ],
               ),
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/signup/screens/signup_phone_verification.dart
+++ b/lib/signup/screens/signup_phone_verification.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../services/phone_auth_service.dart';
 import '../viewmodels/phone_auth_view_model.dart';
+import '../../core/routes/app_routes.dart';
 
 class SignupPhoneVerificationScreen extends StatefulWidget {
   const SignupPhoneVerificationScreen({super.key});
@@ -66,7 +67,11 @@ class _SignupPhoneVerificationScreenState
           // 인증 성공 시 자동으로 다음 페이지로 이동
           if (viewModel.isCodeVerified) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              Navigator.pushNamed(context, '/sign-up/form');
+              Navigator.pushNamed(
+                context,
+                AppRoutes.signUpForm,
+                arguments: _phoneController.text.trim(),
+              );
             });
           }
 

--- a/lib/signup/services/signup_form_service.dart
+++ b/lib/signup/services/signup_form_service.dart
@@ -1,0 +1,108 @@
+import 'package:boulderside_flutter/core/api/api_client.dart';
+import 'package:boulderside_flutter/signup/models/request/phone_lookup_request.dart';
+import 'package:boulderside_flutter/signup/models/request/phone_link_request.dart';
+import 'package:boulderside_flutter/signup/models/request/signup_request.dart';
+import 'package:boulderside_flutter/signup/models/response/phone_lookup_response.dart';
+import 'package:dio/dio.dart';
+import 'dart:io';
+import 'package:http_parser/http_parser.dart';
+import 'dart:convert';
+
+class SignupFormService {
+  SignupFormService() : _dio = ApiClient.dio;
+  final Dio _dio;
+
+  static const String _basePath = '/users';
+
+  // 아이디 중복 확인
+  Future<bool> checkUserId(String username) async {
+    try {
+      final response = await _dio.get(
+        '$_basePath/check-id',
+        queryParameters: {'username': username},
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Failed to check user id');
+      }
+
+      // API 응답에서 사용 가능 여부 반환 (true: 사용 가능, false: 중복)
+      return response.data['data'] as bool;
+    } catch (e) {
+      throw Exception('아이디 중복 확인 실패: $e');
+    }
+  }
+
+  // 전화번호로 사용자 조회
+  Future<PhoneLookupResponse> lookupUserByPhone(String phoneNumber) async {
+    try {
+      final request = PhoneLookupRequest(phoneNumber: phoneNumber);
+      final response = await _dio.post(
+        '$_basePath/phone/lookup',
+        data: request.toJson(),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Failed to lookup user by phone');
+      }
+
+      return PhoneLookupResponse.fromJson(response.data['data']);
+    } catch (e) {
+      throw Exception('전화번호로 사용자 조회 실패: $e');
+    }
+  }
+
+  // 전화번호로 계정 연결
+  Future<void> linkPhoneAccount(
+    String phoneNumber,
+    String email,
+    String password,
+  ) async {
+    try {
+      final request = PhoneLinkRequest(
+        phoneNumber: phoneNumber,
+        email: email,
+        password: password,
+      );
+      final response = await _dio.post(
+        '$_basePath/phone/link-account',
+        data: request.toJson(),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Failed to link phone account');
+      }
+    } catch (e) {
+      throw Exception('전화번호 계정 연결 실패: $e');
+    }
+  }
+
+  // 회원가입 (multipart file 지원)
+  Future<void> signUp(SignupRequest request, {File? profileImage}) async {
+    try {
+      final formData = FormData.fromMap({
+        'data': MultipartFile.fromString(
+          jsonEncode(request.toJson()), // JSON을 문자열로 변환
+          contentType: MediaType('application', 'json'), // Content-Type 명시
+        ),
+        if (profileImage != null)
+          'file': await MultipartFile.fromFile(
+            profileImage.path,
+            filename: profileImage.path.split('/').last,
+          ),
+      });
+
+      final response = await _dio.post(
+        '$_basePath/sign-up',
+        data: formData,
+        options: Options(contentType: 'multipart/form-data'),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Failed to sign up');
+      }
+    } catch (e) {
+      throw Exception('회원가입 실패: $e');
+    }
+  }
+}

--- a/lib/signup/viewmodels/signup_form_view_model.dart
+++ b/lib/signup/viewmodels/signup_form_view_model.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../services/signup_form_service.dart';
+import '../models/response/phone_lookup_response.dart';
+import '../models/request/signup_request.dart';
+import '../models/enums.dart';
+
+class SignupFormViewModel extends ChangeNotifier {
+  final SignupFormService _signupFormService;
+
+  SignupFormViewModel(this._signupFormService);
+
+  // 상태 변수들
+  bool _isLoadingLookup = true;
+  bool _isExistingUser = false;
+  PhoneLookupResponse? _phoneLookupResponse;
+  String? _errorMessage;
+  bool _isSubmitting = false;
+  bool _isSuccess = false;
+  bool _isCheckingEmail = false;
+
+  // 폼 관련 상태
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _passwordConfirmController =
+      TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+
+  String? _selectedGender;
+  bool _emailDuplicateChecked = false;
+  bool _agreeTerms1 = false;
+  bool _agreeTerms2 = false;
+  bool _agreeTerms3 = false;
+
+  // Getters
+  bool get isLoadingLookup => _isLoadingLookup;
+  bool get isExistingUser => _isExistingUser;
+  PhoneLookupResponse? get phoneLookupResponse => _phoneLookupResponse;
+  String? get errorMessage => _errorMessage;
+  bool get isSubmitting => _isSubmitting;
+  bool get isSuccess => _isSuccess;
+  bool get isCheckingEmail => _isCheckingEmail;
+
+  // 폼 관련 Getters
+  TextEditingController get emailController => _emailController;
+  TextEditingController get passwordController => _passwordController;
+  TextEditingController get passwordConfirmController =>
+      _passwordConfirmController;
+  TextEditingController get nameController => _nameController;
+  String? get selectedGender => _selectedGender;
+  bool get emailDuplicateChecked => _emailDuplicateChecked;
+  bool get agreeTerms1 => _agreeTerms1;
+  bool get agreeTerms2 => _agreeTerms2;
+  bool get agreeTerms3 => _agreeTerms3;
+
+  // 폼 유효성 검사
+  bool get allFieldsFilled {
+    if (_isExistingUser) {
+      // 기존 사용자 (연동): 이메일, 비밀번호만 필요
+      return _emailController.text.trim().isNotEmpty &&
+          _passwordController.text.isNotEmpty &&
+          _passwordController.text == _passwordConfirmController.text;
+    } else {
+      // 신규 사용자 (회원가입): 모든 필드 필요
+      return _emailController.text.trim().isNotEmpty &&
+          _passwordController.text.isNotEmpty &&
+          _passwordConfirmController.text.isNotEmpty &&
+          _nameController.text.trim().isNotEmpty &&
+          _passwordController.text == _passwordConfirmController.text &&
+          _selectedGender != null &&
+          _emailDuplicateChecked;
+    }
+  }
+
+  bool get allTermsAgreed => _agreeTerms1 && _agreeTerms2 && _agreeTerms3;
+  bool get canSubmit => allFieldsFilled && allTermsAgreed && !_isSubmitting;
+
+  // 전화번호로 사용자 조회
+  Future<void> lookupUserByPhone(String phoneNumber) async {
+    _isLoadingLookup = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final response = await _signupFormService.lookupUserByPhone(phoneNumber);
+
+      _phoneLookupResponse = response;
+      _isExistingUser = response.exists;
+      _isLoadingLookup = false;
+
+      // 기존 사용자인 경우 UI 자동 채우기
+      if (_isExistingUser) {
+        _populateExistingUserData();
+      }
+
+      notifyListeners();
+    } catch (e) {
+      _isExistingUser = false;
+      _isLoadingLookup = false;
+      _errorMessage = e.toString();
+      notifyListeners();
+    }
+  }
+
+  // 기존 사용자 데이터로 UI 자동 채우기
+  void _populateExistingUserData() {
+    if (_phoneLookupResponse != null) {
+      // 이름 자동 채우기
+      if (_phoneLookupResponse!.name != null) {
+        _nameController.text = _phoneLookupResponse!.name!;
+      }
+
+      // 성별 자동 선택
+      if (_phoneLookupResponse!.userSex != null) {
+        _selectedGender = _phoneLookupResponse!.userSex == UserSex.man
+            ? 'male'
+            : 'female';
+      }
+    }
+  }
+
+  // 폼 필드 변경 핸들러
+  void onFieldChanged() {
+    notifyListeners();
+  }
+
+  // 성별 선택
+  void selectGender(String? gender) {
+    if (!_isExistingUser) {
+      _selectedGender = gender;
+      notifyListeners();
+    }
+  }
+
+  // 이메일 중복 확인
+  Future<void> checkEmailDuplicate() async {
+    final email = _emailController.text.trim();
+    if (email.isEmpty) return;
+
+    _isCheckingEmail = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final isAvailable = await _signupFormService.checkUserId(email);
+
+      if (isAvailable) {
+        _emailDuplicateChecked = true;
+        _errorMessage = null;
+      } else {
+        _emailDuplicateChecked = false;
+        _errorMessage = '이미 사용 중인 아이디입니다.';
+      }
+    } catch (e) {
+      _emailDuplicateChecked = false;
+      _errorMessage = e.toString();
+    } finally {
+      _isCheckingEmail = false;
+      notifyListeners();
+    }
+  }
+
+  // 약관 동의 토글
+  void toggleTerms1() {
+    _agreeTerms1 = !_agreeTerms1;
+    notifyListeners();
+  }
+
+  void toggleTerms2() {
+    _agreeTerms2 = !_agreeTerms2;
+    notifyListeners();
+  }
+
+  void toggleTerms3() {
+    _agreeTerms3 = !_agreeTerms3;
+    notifyListeners();
+  }
+
+  // 폼 제출
+  Future<void> handleSubmit(String phoneNumber) async {
+    if (!canSubmit) return;
+
+    _isSubmitting = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      if (_isExistingUser) {
+        // 기존 사용자 - 계정 연동
+        await _linkPhoneAccount();
+      } else {
+        // 신규 사용자 - 회원가입
+        await _signUp(phoneNumber);
+      }
+    } catch (e) {
+      _errorMessage = e.toString();
+    } finally {
+      _isSubmitting = false;
+      notifyListeners();
+    }
+  }
+
+  // 계정 연동
+  Future<void> _linkPhoneAccount() async {
+    try {
+      await _signupFormService.linkPhoneAccount(
+        _phoneLookupResponse!.phone!,
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+      // 성공 시 처리
+      _isSubmitting = false;
+      _isSuccess = true;
+      notifyListeners();
+    } catch (e) {
+      throw Exception('계정 연동 실패: $e');
+    }
+  }
+
+  // 회원가입
+  Future<void> _signUp(String phoneNumber) async {
+    try {
+      // SignupRequest 생성
+      final signupRequest = SignupRequest(
+        nickname: _nameController.text.trim(), // nickname은 필수
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+        name: _nameController.text.trim(),
+        phone: phoneNumber, // widget.phoneNumber 사용
+        userSex: _selectedGender == 'male' ? UserSex.man : UserSex.woman,
+        userRole: UserRole.roleUser, // 기본값
+        userLevel: Level.v0, // 기본값
+      );
+
+      await _signupFormService.signUp(signupRequest);
+      _isSubmitting = false;
+      _isSuccess = true;
+      notifyListeners();
+    } catch (e) {
+      throw Exception('회원가입 실패: $e');
+    }
+  }
+
+  // 상태 초기화
+  void reset() {
+    _isLoadingLookup = true;
+    _isExistingUser = false;
+    _phoneLookupResponse = null;
+    _errorMessage = null;
+    _isSubmitting = false;
+    _selectedGender = null;
+    _emailDuplicateChecked = false;
+    _agreeTerms1 = false;
+    _agreeTerms2 = false;
+    _agreeTerms3 = false;
+
+    _emailController.clear();
+    _passwordController.clear();
+    _passwordConfirmController.clear();
+    _nameController.clear();
+
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _passwordConfirmController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/signup/widgets/success_dialog.dart
+++ b/lib/signup/widgets/success_dialog.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class SuccessDialog extends StatelessWidget {
+  final bool isExistingUser;
+
+  const SuccessDialog({super.key, required this.isExistingUser});
+
+  static void show(BuildContext context, bool isExistingUser) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return SuccessDialog(isExistingUser: isExistingUser);
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: const Color(0xFF181A20),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: Row(
+        children: [
+          const Icon(Icons.check_circle, color: Color(0xFF00C853), size: 28),
+          const SizedBox(width: 12),
+          Text(
+            isExistingUser ? '계정 연동 완료' : '회원가입 완료',
+            style: const TextStyle(
+              fontFamily: 'Pretendard',
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+      content: Text(
+        isExistingUser
+            ? '계정이 성공적으로 연동되었습니다.\n로그인하여 서비스를 이용해보세요.'
+            : '회원가입이 완료되었습니다.\n로그인하여 서비스를 이용해보세요.',
+        style: const TextStyle(
+          fontFamily: 'Pretendard',
+          color: Colors.white,
+          fontSize: 16,
+          fontWeight: FontWeight.w400,
+        ),
+      ),
+      actions: [
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop(); // 다이얼로그 닫기
+              Navigator.pushNamedAndRemoveUntil(
+                context,
+                '/', // 로그인 화면으로 이동
+                (route) => false,
+              );
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFFF3278),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+            child: const Text(
+              '확인',
+              style: TextStyle(
+                fontFamily: 'Pretendard',
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📌 중점사항

- [x] 회원 가입 관련 DTO 생성 (SignupRequest, PhoneAuthRequest 등)
- [x] 회원 가입 화면 라우팅 시 전화번호 전달 처리
- [x] 회원가입 API 연동 및 서비스 구현

## ℹ️ 참고사항
- 회원 가입 시, 이미 기존의 휴대폰 번호로 가입한 이력이 있을 경우에는 회원가입이 아닌 연동하기로 버튼명을 바꾸었고, 실제 로직도 USER 테이블의 EMAIL, PASSWORD 칸만 UPDATE를 진행합니다.

## 🏷️ 이슈
- 아직 회원 가입 시, 이미지를 저장하는 기능은 포함하지 않았습니다.
- QA 및 구현되지 않은 기능을 모두 구현한 후 이슈를 닫겠습니다.
- close #